### PR TITLE
Fixes to lidi v1.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
 dependencies = [
  "powerfmt",
 ]
@@ -221,9 +221,9 @@ checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "num-conv"
@@ -432,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.39"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -449,15 +449,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "diode"
 version = "1.3.5"
-edition = "2021"
+edition = "2024"
 license = "GPL-3.0"
 
 [dependencies]

--- a/diode-file-bindings/Cargo.toml
+++ b/diode-file-bindings/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "diode-file-bindings"
 version = "1.3.5"
-edition = "2021"
+edition = "2024"
 license = "GPL-3.0"
 
 [dependencies]

--- a/diode-file-bindings/src/lib.rs
+++ b/diode-file-bindings/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
     str::FromStr,
 };
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn diode_new_config(
     ptr_addr: *const c_char,
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn diode_new_config(
     Box::into_raw(config)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn diode_free_config(ptr: *mut file::Config<aux::DiodeSend>) {
     if ptr.is_null() {
@@ -41,7 +41,7 @@ pub unsafe extern "C" fn diode_free_config(ptr: *mut file::Config<aux::DiodeSend
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn diode_send_file(
     ptr: *mut file::Config<aux::DiodeSend>,
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn diode_send_file(
     file::send::send_file(config, &rust_filepath).unwrap_or(0) as u32
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn diode_receive_files(
     ptr: *mut file::Config<aux::DiodeSend>,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,7 +9,7 @@
 project = 'Lidi'
 copyright = '2023, ANSSI-FR'
 author = 'ANSSI-FR'
-release = '1.3.4'
+release = '1.3.5'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/src/receive/client.rs
+++ b/src/receive/client.rs
@@ -61,7 +61,9 @@ where
                         return Ok(());
                     }
                     protocol::MessageType::End => {
-                        log::info!("client {client_id:x}: finished transfer, {transmitted} bytes transmitted");
+                        log::info!(
+                            "client {client_id:x}: finished transfer, {transmitted} bytes transmitted"
+                        );
                         client.flush()?;
                         return Ok(());
                     }

--- a/src/receive/reblock.rs
+++ b/src/receive/reblock.rs
@@ -83,7 +83,9 @@ pub(crate) fn start<F>(receiver: &receive::Receiver<F>) -> Result<(), receive::E
             }
 
             if message_block_id != block_id.wrapping_add(1) {
-                log::warn!("discarding packet with block_id {message_block_id} (current block_id is {block_id})");
+                log::warn!(
+                    "discarding packet with block_id {message_block_id} (current block_id is {block_id})"
+                );
                 continue;
             }
 

--- a/src/receive/reordering.rs
+++ b/src/receive/reordering.rs
@@ -55,7 +55,9 @@ pub(crate) fn start<F>(receiver: &receive::Receiver<F>) -> Result<(), receive::E
             .replace(message)
             .is_some()
         {
-            log::error!("received a new block {block_id} but existing one was not sent to dispatch, synchronization lost, dropping everything");
+            log::error!(
+                "received a new block {block_id} but existing one was not sent to dispatch, synchronization lost, dropping everything"
+            );
             pending_messages.fill_with(|| None);
             receiver.to_dispatch.send(None)?;
         }

--- a/src/sock_utils.rs
+++ b/src/sock_utils.rs
@@ -12,14 +12,16 @@ pub fn set_socket_recv_buffer_size<S: AsRawFd>(socket: &S, size: i32) -> Result<
 }
 
 unsafe fn setsockopt_buffer_size(fd: i32, size: i32, option_name: i32) -> Result<(), io::Error> {
-    let res = unsafe { libc::setsockopt(
-        fd,
-        libc::SOL_SOCKET,
-        option_name,
-        ptr::addr_of!(size).cast::<libc::c_void>(),
-        mem::size_of::<libc::c_int>() as libc::socklen_t,
-    ) };
-    
+    let res = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            option_name,
+            ptr::addr_of!(size).cast::<libc::c_void>(),
+            mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+
     if res == 0 {
         Ok(())
     } else {
@@ -38,13 +40,15 @@ pub fn get_socket_recv_buffer_size<S: AsRawFd>(socket: &S) -> Result<i32, io::Er
 unsafe fn getsockopt_buffer_size(fd: i32, option_name: i32) -> Result<i32, io::Error> {
     let mut sz = 0i32;
     let mut len = mem::size_of::<libc::c_int>() as libc::socklen_t;
-    let res = unsafe { libc::getsockopt(
-        fd,
-        libc::SOL_SOCKET,
-        option_name,
-        ptr::addr_of_mut!(sz).cast::<libc::c_void>(),
-        &mut len,
-    ) };
+    let res = unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            option_name,
+            ptr::addr_of_mut!(sz).cast::<libc::c_void>(),
+            &mut len,
+        )
+    };
     if res == 0 {
         Ok(sz)
     } else {

--- a/src/sock_utils.rs
+++ b/src/sock_utils.rs
@@ -12,17 +12,18 @@ pub fn set_socket_recv_buffer_size<S: AsRawFd>(socket: &S, size: i32) -> Result<
 }
 
 unsafe fn setsockopt_buffer_size(fd: i32, size: i32, option_name: i32) -> Result<(), io::Error> {
-    let res = libc::setsockopt(
+    let res = unsafe { libc::setsockopt(
         fd,
         libc::SOL_SOCKET,
         option_name,
         ptr::addr_of!(size).cast::<libc::c_void>(),
         mem::size_of::<libc::c_int>() as libc::socklen_t,
-    );
+    ) };
+    
     if res == 0 {
         Ok(())
     } else {
-        Err(io::Error::new(io::ErrorKind::Other, "libc::setsockopt"))
+        Err(io::Error::other("libc::setsockopt"))
     }
 }
 
@@ -37,16 +38,16 @@ pub fn get_socket_recv_buffer_size<S: AsRawFd>(socket: &S) -> Result<i32, io::Er
 unsafe fn getsockopt_buffer_size(fd: i32, option_name: i32) -> Result<i32, io::Error> {
     let mut sz = 0i32;
     let mut len = mem::size_of::<libc::c_int>() as libc::socklen_t;
-    let res = libc::getsockopt(
+    let res = unsafe { libc::getsockopt(
         fd,
         libc::SOL_SOCKET,
         option_name,
         ptr::addr_of_mut!(sz).cast::<libc::c_void>(),
         &mut len,
-    );
+    ) };
     if res == 0 {
         Ok(sz)
     } else {
-        Err(io::Error::new(io::ErrorKind::Other, "libc::getsockopt"))
+        Err(io::Error::other("libc::getsockopt"))
     }
 }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -125,7 +125,7 @@ impl UdpMessages<UdpRecv> {
         };
 
         if nb_msg == -1 {
-            Err(io::Error::new(io::ErrorKind::Other, "libc::recvmmsg"))
+            Err(io::Error::other("libc::recvmmsg"))
         } else {
             Ok(self
                 .buffers
@@ -163,7 +163,7 @@ impl UdpMessages<UdpSend> {
                     }
 
                     if nb_msg == -1 {
-                        return Err(io::Error::new(io::ErrorKind::Other, "libc::sendmmsg"));
+                        return Err(io::Error::other("libc::sendmmsg"));
                     }
 
                     let send_duration = start_time.elapsed().as_secs_f64();
@@ -197,7 +197,7 @@ impl UdpMessages<UdpSend> {
                     );
                 }
                 if nb_msg == -1 {
-                    return Err(io::Error::new(io::ErrorKind::Other, "libc::sendmmsg"));
+                    return Err(io::Error::other("libc::sendmmsg"));
                 }
                 if nb_msg as usize != to_send {
                     log::warn!("nb prepared messages doesn't match with nb sent messages");


### PR DESCRIPTION
- Bump rust edition to 2024
- Fix Clippy warnings: Clean up returning errors using io::Error::other()
- Mark no_mangle attribute as unsafe (see https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html)
- Mark direct calls to libc::setsockopt() as unsafe
- Bump documentation release to 1.3.5
- Format sources